### PR TITLE
Add presets, change svg resizing method

### DIFF
--- a/GreatVideoMaker/Form1.Designer.cs
+++ b/GreatVideoMaker/Form1.Designer.cs
@@ -56,6 +56,8 @@ namespace GreatVideoMaker
             this.label11 = new System.Windows.Forms.Label();
             this.openFileDialog2 = new System.Windows.Forms.OpenFileDialog();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.label19 = new System.Windows.Forms.Label();
             this.label15 = new System.Windows.Forms.Label();
             this.button3 = new System.Windows.Forms.Button();
             this.label4 = new System.Windows.Forms.Label();
@@ -78,8 +80,11 @@ namespace GreatVideoMaker
             this.label13 = new System.Windows.Forms.Label();
             this.flyleaf1 = new FlyleafLib.Controls.Flyleaf();
             this.openFileDialog3 = new System.Windows.Forms.OpenFileDialog();
-            this.label19 = new System.Windows.Forms.Label();
-            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
+            this.savePresetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.loadPresetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveFileDialog2 = new System.Windows.Forms.SaveFileDialog();
+            this.openFileDialog4 = new System.Windows.Forms.OpenFileDialog();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.groupBox3.SuspendLayout();
@@ -97,13 +102,15 @@ namespace GreatVideoMaker
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown4)).BeginInit();
             this.groupBox5.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown12)).BeginInit();
+            this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(6, 19);
+            this.button1.Location = new System.Drawing.Point(9, 29);
+            this.button1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(75, 23);
+            this.button1.Size = new System.Drawing.Size(112, 35);
             this.button1.TabIndex = 0;
             this.button1.Text = "Sound";
             this.button1.UseVisualStyleBackColor = true;
@@ -111,9 +118,10 @@ namespace GreatVideoMaker
             // 
             // button2
             // 
-            this.button2.Location = new System.Drawing.Point(6, 19);
+            this.button2.Location = new System.Drawing.Point(9, 29);
+            this.button2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(75, 23);
+            this.button2.Size = new System.Drawing.Size(112, 35);
             this.button2.TabIndex = 1;
             this.button2.Text = "Video";
             this.button2.UseVisualStyleBackColor = true;
@@ -122,9 +130,10 @@ namespace GreatVideoMaker
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(87, 24);
+            this.label1.Location = new System.Drawing.Point(130, 37);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(35, 13);
+            this.label1.Size = new System.Drawing.Size(51, 20);
             this.label1.TabIndex = 2;
             this.label1.Text = "label1";
             // 
@@ -140,9 +149,10 @@ namespace GreatVideoMaker
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(87, 24);
+            this.label2.Location = new System.Drawing.Point(130, 37);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(35, 13);
+            this.label2.Size = new System.Drawing.Size(51, 20);
             this.label2.TabIndex = 3;
             this.label2.Text = "label2";
             // 
@@ -154,18 +164,21 @@ namespace GreatVideoMaker
             this.groupBox1.Controls.Add(this.label17);
             this.groupBox1.Controls.Add(this.button1);
             this.groupBox1.Controls.Add(this.label1);
-            this.groupBox1.Location = new System.Drawing.Point(12, 66);
+            this.groupBox1.Location = new System.Drawing.Point(13, 138);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(426, 106);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox1.Size = new System.Drawing.Size(639, 163);
             this.groupBox1.TabIndex = 4;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Source files";
             // 
             // button6
             // 
-            this.button6.Location = new System.Drawing.Point(6, 77);
+            this.button6.Location = new System.Drawing.Point(9, 118);
+            this.button6.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.button6.Name = "button6";
-            this.button6.Size = new System.Drawing.Size(75, 23);
+            this.button6.Size = new System.Drawing.Size(112, 35);
             this.button6.TabIndex = 5;
             this.button6.Text = "Image";
             this.button6.UseVisualStyleBackColor = true;
@@ -174,17 +187,19 @@ namespace GreatVideoMaker
             // label18
             // 
             this.label18.AutoSize = true;
-            this.label18.Location = new System.Drawing.Point(87, 82);
+            this.label18.Location = new System.Drawing.Point(130, 126);
+            this.label18.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label18.Name = "label18";
-            this.label18.Size = new System.Drawing.Size(41, 13);
+            this.label18.Size = new System.Drawing.Size(60, 20);
             this.label18.TabIndex = 6;
             this.label18.Text = "label18";
             // 
             // button5
             // 
-            this.button5.Location = new System.Drawing.Point(6, 48);
+            this.button5.Location = new System.Drawing.Point(9, 74);
+            this.button5.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.button5.Name = "button5";
-            this.button5.Size = new System.Drawing.Size(75, 23);
+            this.button5.Size = new System.Drawing.Size(112, 35);
             this.button5.TabIndex = 3;
             this.button5.Text = "Svg";
             this.button5.UseVisualStyleBackColor = true;
@@ -193,9 +208,10 @@ namespace GreatVideoMaker
             // label17
             // 
             this.label17.AutoSize = true;
-            this.label17.Location = new System.Drawing.Point(87, 53);
+            this.label17.Location = new System.Drawing.Point(130, 82);
+            this.label17.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label17.Name = "label17";
-            this.label17.Size = new System.Drawing.Size(41, 13);
+            this.label17.Size = new System.Drawing.Size(60, 20);
             this.label17.TabIndex = 4;
             this.label17.Text = "label17";
             // 
@@ -203,9 +219,11 @@ namespace GreatVideoMaker
             // 
             this.groupBox2.Controls.Add(this.button2);
             this.groupBox2.Controls.Add(this.label2);
-            this.groupBox2.Location = new System.Drawing.Point(12, 284);
+            this.groupBox2.Location = new System.Drawing.Point(13, 475);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(426, 48);
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox2.Size = new System.Drawing.Size(639, 74);
             this.groupBox2.TabIndex = 5;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Output files";
@@ -221,18 +239,21 @@ namespace GreatVideoMaker
             this.groupBox3.Controls.Add(this.label6);
             this.groupBox3.Controls.Add(this.numericUpDown1);
             this.groupBox3.Controls.Add(this.label5);
-            this.groupBox3.Location = new System.Drawing.Point(12, 178);
+            this.groupBox3.Location = new System.Drawing.Point(14, 311);
+            this.groupBox3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(426, 100);
+            this.groupBox3.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox3.Size = new System.Drawing.Size(639, 154);
             this.groupBox3.TabIndex = 6;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "parameters";
             // 
             // button4
             // 
-            this.button4.Location = new System.Drawing.Point(6, 71);
+            this.button4.Location = new System.Drawing.Point(9, 109);
+            this.button4.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.button4.Name = "button4";
-            this.button4.Size = new System.Drawing.Size(75, 23);
+            this.button4.Size = new System.Drawing.Size(112, 35);
             this.button4.TabIndex = 11;
             this.button4.Text = "Analyze";
             this.button4.UseVisualStyleBackColor = true;
@@ -241,9 +262,10 @@ namespace GreatVideoMaker
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(98, 76);
+            this.label3.Location = new System.Drawing.Point(147, 117);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(24, 13);
+            this.label3.Size = new System.Drawing.Size(31, 20);
             this.label3.TabIndex = 10;
             this.label3.Text = "0/0";
             // 
@@ -251,39 +273,43 @@ namespace GreatVideoMaker
             // 
             this.progressBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressBar1.Location = new System.Drawing.Point(90, 71);
+            this.progressBar1.Location = new System.Drawing.Point(135, 109);
+            this.progressBar1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.progressBar1.Name = "progressBar1";
-            this.progressBar1.Size = new System.Drawing.Size(330, 23);
+            this.progressBar1.Size = new System.Drawing.Size(495, 35);
             this.progressBar1.Step = 1;
             this.progressBar1.TabIndex = 9;
             // 
             // comboBox1
             // 
             this.comboBox1.FormattingEnabled = true;
-            this.comboBox1.Location = new System.Drawing.Point(90, 44);
+            this.comboBox1.Location = new System.Drawing.Point(135, 68);
+            this.comboBox1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.comboBox1.Name = "comboBox1";
-            this.comboBox1.Size = new System.Drawing.Size(120, 21);
+            this.comboBox1.Size = new System.Drawing.Size(178, 28);
             this.comboBox1.TabIndex = 8;
             // 
             // label16
             // 
             this.label16.AutoSize = true;
-            this.label16.Location = new System.Drawing.Point(6, 47);
+            this.label16.Location = new System.Drawing.Point(9, 72);
+            this.label16.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label16.Name = "label16";
-            this.label16.Size = new System.Drawing.Size(43, 13);
+            this.label16.Size = new System.Drawing.Size(61, 20);
             this.label16.TabIndex = 7;
             this.label16.Text = "window";
             // 
             // numericUpDown2
             // 
-            this.numericUpDown2.Location = new System.Drawing.Point(300, 19);
+            this.numericUpDown2.Location = new System.Drawing.Point(450, 29);
+            this.numericUpDown2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.numericUpDown2.Maximum = new decimal(new int[] {
             29,
             0,
             0,
             0});
             this.numericUpDown2.Name = "numericUpDown2";
-            this.numericUpDown2.Size = new System.Drawing.Size(120, 20);
+            this.numericUpDown2.Size = new System.Drawing.Size(180, 26);
             this.numericUpDown2.TabIndex = 6;
             this.numericUpDown2.Value = new decimal(new int[] {
             1,
@@ -294,15 +320,17 @@ namespace GreatVideoMaker
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(216, 21);
+            this.label6.Location = new System.Drawing.Point(324, 32);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(57, 13);
+            this.label6.Size = new System.Drawing.Size(83, 20);
             this.label6.TabIndex = 5;
             this.label6.Text = "lookahead";
             // 
             // numericUpDown1
             // 
-            this.numericUpDown1.Location = new System.Drawing.Point(90, 19);
+            this.numericUpDown1.Location = new System.Drawing.Point(135, 29);
+            this.numericUpDown1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.numericUpDown1.Maximum = new decimal(new int[] {
             60,
             0,
@@ -314,7 +342,7 @@ namespace GreatVideoMaker
             0,
             0});
             this.numericUpDown1.Name = "numericUpDown1";
-            this.numericUpDown1.Size = new System.Drawing.Size(120, 20);
+            this.numericUpDown1.Size = new System.Drawing.Size(180, 26);
             this.numericUpDown1.TabIndex = 4;
             this.numericUpDown1.Value = new decimal(new int[] {
             30,
@@ -325,22 +353,24 @@ namespace GreatVideoMaker
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(6, 21);
+            this.label5.Location = new System.Drawing.Point(9, 32);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(51, 13);
+            this.label5.Size = new System.Drawing.Size(78, 20);
             this.label5.TabIndex = 3;
             this.label5.Text = "framerate";
             // 
             // numericUpDown8
             // 
-            this.numericUpDown8.Location = new System.Drawing.Point(153, 19);
+            this.numericUpDown8.Location = new System.Drawing.Point(230, 29);
+            this.numericUpDown8.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.numericUpDown8.Maximum = new decimal(new int[] {
             2160,
             0,
             0,
             0});
             this.numericUpDown8.Name = "numericUpDown8";
-            this.numericUpDown8.Size = new System.Drawing.Size(57, 20);
+            this.numericUpDown8.Size = new System.Drawing.Size(86, 26);
             this.numericUpDown8.TabIndex = 13;
             this.numericUpDown8.Value = new decimal(new int[] {
             720,
@@ -350,14 +380,15 @@ namespace GreatVideoMaker
             // 
             // numericUpDown9
             // 
-            this.numericUpDown9.Location = new System.Drawing.Point(90, 19);
+            this.numericUpDown9.Location = new System.Drawing.Point(135, 29);
+            this.numericUpDown9.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.numericUpDown9.Maximum = new decimal(new int[] {
             3840,
             0,
             0,
             0});
             this.numericUpDown9.Name = "numericUpDown9";
-            this.numericUpDown9.Size = new System.Drawing.Size(57, 20);
+            this.numericUpDown9.Size = new System.Drawing.Size(86, 26);
             this.numericUpDown9.TabIndex = 12;
             this.numericUpDown9.Value = new decimal(new int[] {
             1280,
@@ -368,15 +399,17 @@ namespace GreatVideoMaker
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(6, 21);
+            this.label11.Location = new System.Drawing.Point(9, 32);
+            this.label11.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(64, 13);
+            this.label11.Size = new System.Drawing.Size(94, 20);
             this.label11.TabIndex = 11;
             this.label11.Text = "width,height";
             // 
             // openFileDialog2
             // 
             this.openFileDialog2.FileName = "openFileDialog2";
+            this.openFileDialog2.Filter = "Vector graphics files | *.svg";
             // 
             // groupBox4
             // 
@@ -400,27 +433,49 @@ namespace GreatVideoMaker
             this.groupBox4.Controls.Add(this.label8);
             this.groupBox4.Controls.Add(this.numericUpDown4);
             this.groupBox4.Controls.Add(this.label9);
-            this.groupBox4.Location = new System.Drawing.Point(12, 338);
+            this.groupBox4.Location = new System.Drawing.Point(13, 559);
+            this.groupBox4.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(426, 152);
+            this.groupBox4.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox4.Size = new System.Drawing.Size(639, 234);
             this.groupBox4.TabIndex = 7;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "parameters";
             // 
+            // textBox1
+            // 
+            this.textBox1.Location = new System.Drawing.Point(135, 149);
+            this.textBox1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.textBox1.Name = "textBox1";
+            this.textBox1.Size = new System.Drawing.Size(178, 26);
+            this.textBox1.TabIndex = 19;
+            // 
+            // label19
+            // 
+            this.label19.AutoSize = true;
+            this.label19.Location = new System.Drawing.Point(9, 152);
+            this.label19.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label19.Name = "label19";
+            this.label19.Size = new System.Drawing.Size(34, 20);
+            this.label19.TabIndex = 18;
+            this.label19.Text = "title";
+            // 
             // label15
             // 
             this.label15.AutoSize = true;
-            this.label15.Location = new System.Drawing.Point(216, 128);
+            this.label15.Location = new System.Drawing.Point(324, 197);
+            this.label15.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label15.Name = "label15";
-            this.label15.Size = new System.Drawing.Size(13, 13);
+            this.label15.Size = new System.Drawing.Size(18, 20);
             this.label15.TabIndex = 17;
             this.label15.Text = "0";
             // 
             // button3
             // 
-            this.button3.Location = new System.Drawing.Point(6, 123);
+            this.button3.Location = new System.Drawing.Point(9, 189);
+            this.button3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.button3.Name = "button3";
-            this.button3.Size = new System.Drawing.Size(75, 23);
+            this.button3.Size = new System.Drawing.Size(112, 35);
             this.button3.TabIndex = 16;
             this.button3.Text = "Render";
             this.button3.UseVisualStyleBackColor = true;
@@ -429,9 +484,10 @@ namespace GreatVideoMaker
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(98, 128);
+            this.label4.Location = new System.Drawing.Point(147, 197);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(24, 13);
+            this.label4.Size = new System.Drawing.Size(31, 20);
             this.label4.TabIndex = 15;
             this.label4.Text = "0/0";
             // 
@@ -439,14 +495,16 @@ namespace GreatVideoMaker
             // 
             this.progressBar2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressBar2.Location = new System.Drawing.Point(90, 123);
+            this.progressBar2.Location = new System.Drawing.Point(135, 189);
+            this.progressBar2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.progressBar2.Name = "progressBar2";
-            this.progressBar2.Size = new System.Drawing.Size(330, 23);
+            this.progressBar2.Size = new System.Drawing.Size(495, 35);
             this.progressBar2.TabIndex = 14;
             // 
             // numericUpDown10
             // 
-            this.numericUpDown10.Location = new System.Drawing.Point(153, 71);
+            this.numericUpDown10.Location = new System.Drawing.Point(230, 109);
+            this.numericUpDown10.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.numericUpDown10.Maximum = new decimal(new int[] {
             108,
             0,
@@ -458,7 +516,7 @@ namespace GreatVideoMaker
             0,
             -2147483648});
             this.numericUpDown10.Name = "numericUpDown10";
-            this.numericUpDown10.Size = new System.Drawing.Size(57, 20);
+            this.numericUpDown10.Size = new System.Drawing.Size(86, 26);
             this.numericUpDown10.TabIndex = 13;
             this.numericUpDown10.Value = new decimal(new int[] {
             42,
@@ -468,7 +526,8 @@ namespace GreatVideoMaker
             // 
             // numericUpDown11
             // 
-            this.numericUpDown11.Location = new System.Drawing.Point(90, 71);
+            this.numericUpDown11.Location = new System.Drawing.Point(135, 109);
+            this.numericUpDown11.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.numericUpDown11.Maximum = new decimal(new int[] {
             108,
             0,
@@ -480,7 +539,7 @@ namespace GreatVideoMaker
             0,
             -2147483648});
             this.numericUpDown11.Name = "numericUpDown11";
-            this.numericUpDown11.Size = new System.Drawing.Size(57, 20);
+            this.numericUpDown11.Size = new System.Drawing.Size(86, 26);
             this.numericUpDown11.TabIndex = 12;
             this.numericUpDown11.Value = new decimal(new int[] {
             30,
@@ -491,22 +550,24 @@ namespace GreatVideoMaker
             // label12
             // 
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(6, 73);
+            this.label12.Location = new System.Drawing.Point(9, 112);
+            this.label12.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(66, 13);
+            this.label12.Size = new System.Drawing.Size(99, 20);
             this.label12.TabIndex = 11;
             this.label12.Text = "note borders";
             // 
             // numericUpDown7
             // 
-            this.numericUpDown7.Location = new System.Drawing.Point(363, 45);
+            this.numericUpDown7.Location = new System.Drawing.Point(544, 69);
+            this.numericUpDown7.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.numericUpDown7.Maximum = new decimal(new int[] {
             30,
             0,
             0,
             0});
             this.numericUpDown7.Name = "numericUpDown7";
-            this.numericUpDown7.Size = new System.Drawing.Size(57, 20);
+            this.numericUpDown7.Size = new System.Drawing.Size(86, 26);
             this.numericUpDown7.TabIndex = 10;
             this.numericUpDown7.Value = new decimal(new int[] {
             8,
@@ -516,7 +577,8 @@ namespace GreatVideoMaker
             // 
             // numericUpDown6
             // 
-            this.numericUpDown6.Location = new System.Drawing.Point(300, 45);
+            this.numericUpDown6.Location = new System.Drawing.Point(450, 69);
+            this.numericUpDown6.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.numericUpDown6.Maximum = new decimal(new int[] {
             30,
             0,
@@ -528,7 +590,7 @@ namespace GreatVideoMaker
             0,
             0});
             this.numericUpDown6.Name = "numericUpDown6";
-            this.numericUpDown6.Size = new System.Drawing.Size(57, 20);
+            this.numericUpDown6.Size = new System.Drawing.Size(86, 26);
             this.numericUpDown6.TabIndex = 9;
             this.numericUpDown6.Value = new decimal(new int[] {
             8,
@@ -539,22 +601,24 @@ namespace GreatVideoMaker
             // label10
             // 
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(216, 47);
+            this.label10.Location = new System.Drawing.Point(324, 72);
+            this.label10.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(79, 13);
+            this.label10.Size = new System.Drawing.Size(116, 20);
             this.label10.TabIndex = 8;
             this.label10.Text = "decay Exp,time";
             // 
             // numericUpDown5
             // 
-            this.numericUpDown5.Location = new System.Drawing.Point(153, 45);
+            this.numericUpDown5.Location = new System.Drawing.Point(230, 69);
+            this.numericUpDown5.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.numericUpDown5.Maximum = new decimal(new int[] {
             360,
             0,
             0,
             0});
             this.numericUpDown5.Name = "numericUpDown5";
-            this.numericUpDown5.Size = new System.Drawing.Size(57, 20);
+            this.numericUpDown5.Size = new System.Drawing.Size(86, 26);
             this.numericUpDown5.TabIndex = 7;
             this.numericUpDown5.Value = new decimal(new int[] {
             60,
@@ -564,14 +628,15 @@ namespace GreatVideoMaker
             // 
             // numericUpDown3
             // 
-            this.numericUpDown3.Location = new System.Drawing.Point(90, 45);
+            this.numericUpDown3.Location = new System.Drawing.Point(135, 69);
+            this.numericUpDown3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.numericUpDown3.Maximum = new decimal(new int[] {
             360,
             0,
             0,
             0});
             this.numericUpDown3.Name = "numericUpDown3";
-            this.numericUpDown3.Size = new System.Drawing.Size(57, 20);
+            this.numericUpDown3.Size = new System.Drawing.Size(86, 26);
             this.numericUpDown3.TabIndex = 6;
             this.numericUpDown3.Value = new decimal(new int[] {
             160,
@@ -582,15 +647,17 @@ namespace GreatVideoMaker
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(6, 47);
+            this.label8.Location = new System.Drawing.Point(9, 72);
+            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(85, 13);
+            this.label8.Size = new System.Drawing.Size(127, 20);
             this.label8.TabIndex = 5;
             this.label8.Text = "color start,length";
             // 
             // numericUpDown4
             // 
-            this.numericUpDown4.Location = new System.Drawing.Point(300, 19);
+            this.numericUpDown4.Location = new System.Drawing.Point(450, 29);
+            this.numericUpDown4.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.numericUpDown4.Maximum = new decimal(new int[] {
             2048,
             0,
@@ -602,7 +669,7 @@ namespace GreatVideoMaker
             0,
             0});
             this.numericUpDown4.Name = "numericUpDown4";
-            this.numericUpDown4.Size = new System.Drawing.Size(120, 20);
+            this.numericUpDown4.Size = new System.Drawing.Size(180, 26);
             this.numericUpDown4.TabIndex = 4;
             this.numericUpDown4.Value = new decimal(new int[] {
             128,
@@ -613,9 +680,10 @@ namespace GreatVideoMaker
             // label9
             // 
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(216, 21);
+            this.label9.Location = new System.Drawing.Point(324, 32);
+            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(61, 13);
+            this.label9.Size = new System.Drawing.Size(91, 20);
             this.label9.TabIndex = 3;
             this.label9.Text = "barRelation";
             // 
@@ -625,9 +693,11 @@ namespace GreatVideoMaker
             this.groupBox5.Controls.Add(this.numericUpDown12);
             this.groupBox5.Controls.Add(this.label7);
             this.groupBox5.Controls.Add(this.label13);
-            this.groupBox5.Location = new System.Drawing.Point(12, 12);
+            this.groupBox5.Location = new System.Drawing.Point(13, 54);
+            this.groupBox5.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Size = new System.Drawing.Size(426, 48);
+            this.groupBox5.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox5.Size = new System.Drawing.Size(639, 74);
             this.groupBox5.TabIndex = 8;
             this.groupBox5.TabStop = false;
             this.groupBox5.Text = "info";
@@ -635,15 +705,17 @@ namespace GreatVideoMaker
             // label14
             // 
             this.label14.AutoSize = true;
-            this.label14.Location = new System.Drawing.Point(360, 20);
+            this.label14.Location = new System.Drawing.Point(540, 31);
+            this.label14.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(49, 13);
+            this.label14.Size = new System.Drawing.Size(71, 20);
             this.label14.TabIndex = 10;
             this.label14.Text = "300, 120";
             // 
             // numericUpDown12
             // 
-            this.numericUpDown12.Location = new System.Drawing.Point(90, 18);
+            this.numericUpDown12.Location = new System.Drawing.Point(135, 28);
+            this.numericUpDown12.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.numericUpDown12.Maximum = new decimal(new int[] {
             4096,
             0,
@@ -655,7 +727,7 @@ namespace GreatVideoMaker
             0,
             0});
             this.numericUpDown12.Name = "numericUpDown12";
-            this.numericUpDown12.Size = new System.Drawing.Size(120, 20);
+            this.numericUpDown12.Size = new System.Drawing.Size(180, 26);
             this.numericUpDown12.TabIndex = 8;
             this.numericUpDown12.Value = new decimal(new int[] {
             4,
@@ -667,60 +739,86 @@ namespace GreatVideoMaker
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(6, 20);
+            this.label7.Location = new System.Drawing.Point(9, 31);
+            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(58, 13);
+            this.label7.Size = new System.Drawing.Size(87, 20);
             this.label7.TabIndex = 7;
             this.label7.Text = "processors";
             // 
             // label13
             // 
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(288, 20);
+            this.label13.Location = new System.Drawing.Point(432, 31);
+            this.label13.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(49, 13);
+            this.label13.Size = new System.Drawing.Size(71, 20);
             this.label13.TabIndex = 9;
             this.label13.Text = "200, 190";
             // 
             // flyleaf1
             // 
             this.flyleaf1.BackColor = System.Drawing.Color.Black;
-            this.flyleaf1.Location = new System.Drawing.Point(444, 12);
+            this.flyleaf1.Location = new System.Drawing.Point(674, 54);
+            this.flyleaf1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.flyleaf1.Name = "flyleaf1";
-            this.flyleaf1.Size = new System.Drawing.Size(854, 480);
+            this.flyleaf1.Size = new System.Drawing.Size(1281, 738);
             this.flyleaf1.TabIndex = 9;
             // 
             // openFileDialog3
             // 
             this.openFileDialog3.FileName = "openFileDialog3";
             // 
-            // label19
+            // menuStrip1
             // 
-            this.label19.AutoSize = true;
-            this.label19.Location = new System.Drawing.Point(6, 99);
-            this.label19.Name = "label19";
-            this.label19.Size = new System.Drawing.Size(23, 13);
-            this.label19.TabIndex = 18;
-            this.label19.Text = "title";
+            this.menuStrip1.GripMargin = new System.Windows.Forms.Padding(2, 2, 0, 2);
+            this.menuStrip1.ImageScalingSize = new System.Drawing.Size(24, 24);
+            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.savePresetToolStripMenuItem,
+            this.loadPresetToolStripMenuItem});
+            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
+            this.menuStrip1.Name = "menuStrip1";
+            this.menuStrip1.Size = new System.Drawing.Size(1968, 33);
+            this.menuStrip1.TabIndex = 10;
+            this.menuStrip1.Text = "menuStrip1";
             // 
-            // textBox1
+            // savePresetToolStripMenuItem
             // 
-            this.textBox1.Location = new System.Drawing.Point(90, 97);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(120, 20);
-            this.textBox1.TabIndex = 19;
+            this.savePresetToolStripMenuItem.Name = "savePresetToolStripMenuItem";
+            this.savePresetToolStripMenuItem.Size = new System.Drawing.Size(119, 29);
+            this.savePresetToolStripMenuItem.Text = "Save preset";
+            this.savePresetToolStripMenuItem.Click += new System.EventHandler(this.savePresetToolStripMenuItem_Click);
+            // 
+            // loadPresetToolStripMenuItem
+            // 
+            this.loadPresetToolStripMenuItem.Name = "loadPresetToolStripMenuItem";
+            this.loadPresetToolStripMenuItem.Size = new System.Drawing.Size(121, 29);
+            this.loadPresetToolStripMenuItem.Text = "Load preset";
+            this.loadPresetToolStripMenuItem.Click += new System.EventHandler(this.loadPresetToolStripMenuItem_Click);
+            // 
+            // saveFileDialog2
+            // 
+            this.saveFileDialog2.Filter = "Config files | *.cfg";
+            // 
+            // openFileDialog4
+            // 
+            this.openFileDialog4.FileName = "openFileDialog4";
+            this.openFileDialog4.Filter = "Config files | *.cfg";
             // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1312, 504);
+            this.ClientSize = new System.Drawing.Size(1968, 807);
             this.Controls.Add(this.flyleaf1);
             this.Controls.Add(this.groupBox5);
             this.Controls.Add(this.groupBox4);
             this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.menuStrip1);
+            this.MainMenuStrip = this.menuStrip1;
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.Name = "Form1";
             this.Text = "g";
             this.groupBox1.ResumeLayout(false);
@@ -745,7 +843,10 @@ namespace GreatVideoMaker
             this.groupBox5.ResumeLayout(false);
             this.groupBox5.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown12)).EndInit();
+            this.menuStrip1.ResumeLayout(false);
+            this.menuStrip1.PerformLayout();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -802,6 +903,11 @@ namespace GreatVideoMaker
         private System.Windows.Forms.OpenFileDialog openFileDialog3;
         private System.Windows.Forms.TextBox textBox1;
         private System.Windows.Forms.Label label19;
+        private System.Windows.Forms.MenuStrip menuStrip1;
+        private System.Windows.Forms.ToolStripMenuItem savePresetToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem loadPresetToolStripMenuItem;
+        private System.Windows.Forms.SaveFileDialog saveFileDialog2;
+        private System.Windows.Forms.OpenFileDialog openFileDialog4;
     }
 }
 

--- a/GreatVideoMaker/Form1.cs
+++ b/GreatVideoMaker/Form1.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -187,6 +188,62 @@ namespace GreatVideoMaker
             if (openFileDialog3.ShowDialog() == DialogResult.OK)
             {
                 ImagePath = openFileDialog3.FileName;
+            }
+        }
+
+        private void savePresetToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (saveFileDialog2.ShowDialog() == DialogResult.OK)
+            {
+                List<string> lines = new List<string>();
+
+                lines.Add(numericUpDown12.Value.ToString());
+                lines.Add(label1.Text);
+                lines.Add(label17.Text);
+                lines.Add(label18.Text);
+                lines.Add(numericUpDown1.Value.ToString());
+                lines.Add(numericUpDown2.Value.ToString());
+                lines.Add(comboBox1.Text);
+                lines.Add(label2.Text);
+                lines.Add(numericUpDown9.Value.ToString());
+                lines.Add(numericUpDown8.Value.ToString());
+                lines.Add(numericUpDown4.Value.ToString());
+                lines.Add(numericUpDown3.Value.ToString());
+                lines.Add(numericUpDown5.Value.ToString());
+                lines.Add(numericUpDown6.Value.ToString());
+                lines.Add(numericUpDown7.Value.ToString());
+                lines.Add(numericUpDown11.Value.ToString());
+                lines.Add(numericUpDown10.Value.ToString());
+                lines.Add(textBox1.Text);
+
+                File.WriteAllLines(saveFileDialog2.FileName, lines);
+            }
+        }
+
+        private void loadPresetToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (openFileDialog4.ShowDialog() == DialogResult.OK)
+            {
+                string[] lines = File.ReadAllLines(openFileDialog4.FileName);
+
+                numericUpDown12.Value = decimal.Parse(lines[0]);
+                label1.Text = lines[1];
+                label17.Text = lines[2];
+                label18.Text = lines[3];
+                numericUpDown1.Value = decimal.Parse(lines[4]);
+                numericUpDown2.Value = decimal.Parse(lines[5]);
+                comboBox1.Text = lines[6];
+                label12.Text = lines[7];
+                numericUpDown9.Value = decimal.Parse(lines[8]);
+                numericUpDown8.Value = decimal.Parse(lines[9]);
+                numericUpDown4.Value = decimal.Parse(lines[10]);
+                numericUpDown3.Value = decimal.Parse(lines[11]);
+                numericUpDown5.Value = decimal.Parse(lines[12]);
+                numericUpDown6.Value = decimal.Parse(lines[13]);
+                numericUpDown7.Value = decimal.Parse(lines[14]);
+                numericUpDown11.Value = decimal.Parse(lines[15]);
+                numericUpDown10.Value = decimal.Parse(lines[16]);
+                textBox1.Text = lines[17];
             }
         }
     }

--- a/GreatVideoMaker/Form1.resx
+++ b/GreatVideoMaker/Form1.resx
@@ -129,4 +129,13 @@
   <metadata name="openFileDialog3.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>433, 17</value>
   </metadata>
+  <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>627, 17</value>
+  </metadata>
+  <metadata name="saveFileDialog2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>783, 17</value>
+  </metadata>
+  <metadata name="openFileDialog4.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>971, 17</value>
+  </metadata>
 </root>

--- a/GreatVideoMaker/VideoRenderer.cs
+++ b/GreatVideoMaker/VideoRenderer.cs
@@ -135,13 +135,18 @@ namespace GreatVideoMaker
             SvgDocument document = SvgDocument.Open(svgFilepath);
             using (GraphicsPath path = SvgConverter.ToGraphicsPath(document))
             {
-
                 float unit = frameSize.Width / 7;
-                path.Transform(new Matrix(path.GetBounds(), new PointF[] {
+                PointF[] option1 = new PointF[] {
                     new PointF(unit, unit),
                     new PointF(frameSize.Width - unit, unit),
                     new PointF(unit, frameSize.Height - unit)
-                }));
+                };
+                PointF[] option2 = new PointF[] {
+                    new PointF(document.Bounds.X, document.Bounds.Y),
+                    new PointF(document.Bounds.X + document.Bounds.Width, document.Bounds.Y),
+                    new PointF(document.Bounds.X, document.Bounds.Y + document.Bounds.Height)
+                };
+                path.Transform(new Matrix(path.GetBounds(), option2));;
                 using (Matrix mx = new Matrix(1, 0, 0, 1, 0, 0))
                 {
                     path.Flatten(mx, 0.1f);

--- a/SvgTest/Form1.cs
+++ b/SvgTest/Form1.cs
@@ -19,7 +19,7 @@ namespace SvgTest
         {
             InitializeComponent();
 
-            string filename = "D:\\josuemb_house-silhouette.svg"; // put something here to test, cant be bothered to make fancy tester
+            string filename = "D:\\randomsound\\bbb-real-background.svg"; // put something here to test, cant be bothered to make fancy tester
 
             SvgDocument document = SvgDocument.Open(filename);
             RectangleF rect = document.Path.GetBounds();


### PR DESCRIPTION
Presets - save and load them
Svg resizing - if svg viewbox and image are same size, then they now overlap perfectly. previously svg got resized based on its drawn dimensions